### PR TITLE
Use rp2040-hal gpio pins for RX and TX definition

### DIFF
--- a/examples/can2040_demo.rs
+++ b/examples/can2040_demo.rs
@@ -20,8 +20,6 @@ use rp2040_hal::{entry, pac, Sio, Watchdog};
 use rp_pico::XOSC_CRYSTAL_FREQ;
 
 const CONFIG_CANBUS_FREQUENCY: u32 = 10_000;
-const CONFIG_RP2040_CANBUS_GPIO_RX: u32 = 26;
-const CONFIG_RP2040_CANBUS_GPIO_TX: u32 = 27;
 
 #[global_allocator]
 pub static ALLOCATOR: CortexMHeap = CortexMHeap::empty();
@@ -59,11 +57,11 @@ fn main() -> ! {
 
     let mut led_pin = pins.gpio25.into_push_pull_output();
 
-    let mut can_bus = can2040::initialize_cbus(
+    let mut can_bus = Can2040::new(
         &mut core,
         CONFIG_CANBUS_FREQUENCY,
-        CONFIG_RP2040_CANBUS_GPIO_RX,
-        CONFIG_RP2040_CANBUS_GPIO_TX,
+        pins.gpio26.reconfigure(),
+        pins.gpio27.reconfigure(),
     );
 
     let mut count = 0u64;

--- a/src/core.rs
+++ b/src/core.rs
@@ -8,8 +8,9 @@ use cortex_m::asm::wfi;
 use cortex_m::interrupt::Mutex;
 use defmt::{debug, Format};
 use embedded_can::{ErrorKind, ExtendedId, Id, StandardId};
-use rp2040_hal::pac;
+use rp2040_hal::gpio::{FunctionNull, PinId, PullNone};
 use rp2040_hal::pac::interrupt;
+use rp2040_hal::{gpio::Pin, pac};
 
 use crate::core::can2040_lib::{
     can2040, can2040_bitunstuffer, can2040_callback_config, can2040_check_transmit, can2040_msg,
@@ -269,6 +270,7 @@ fn PIO0_IRQ_0() {
 /// for Can2040. Additionally, when enabling Can2040, we forcibly set the
 /// priority of Can2040 to 0 to ensure that communication interrupts can
 /// receive the most real-time response.
+#[deprecated(note = "does not use hal for pins, use Can2040::new instead")]
 pub fn initialize_cbus(
     core: &mut cortex_m::Peripherals,
     baud_rate: u32,
@@ -288,5 +290,35 @@ pub fn initialize_cbus(
         core.NVIC.set_priority(pac::Interrupt::PIO0_IRQ_0, 0);
         pac::NVIC::unmask(pac::Interrupt::PIO0_IRQ_0);
         Can2040 {}
+    }
+}
+
+impl Can2040 {
+    pub fn new<RX: PinId, TX: PinId>(
+        core: &mut cortex_m::Peripherals,
+        baud_rate: u32,
+        can_rx: Pin<RX, FunctionNull, PullNone>,
+        can_tx: Pin<TX, FunctionNull, PullNone>,
+    ) -> Self {
+        unsafe {
+            assert!(CBUS.is_none());
+            CBUS = Some(can2040::new());
+            let cbus = CBUS.as_mut().unwrap();
+            let cbus_ptr = &mut *cbus as *mut _;
+            can2040_setup(cbus_ptr, 0);
+            can2040_callback_config(cbus_ptr, Some(can2040_cb));
+            can2040_start(
+                cbus_ptr,
+                RP2040_SYS_FREQ,
+                baud_rate,
+                can_rx.id().num as u32,
+                can_tx.id().num as u32,
+            );
+
+            // Enable interrupts and set priority for it.
+            core.NVIC.set_priority(pac::Interrupt::PIO0_IRQ_0, 0);
+            pac::NVIC::unmask(pac::Interrupt::PIO0_IRQ_0);
+            Can2040 {}
+        }
     }
 }


### PR DESCRIPTION
The library currently does not benefit from rusts type safety, when defining the gpio pins for rx and tx. In this commit I created a new constructor, that uses rp2040::gpio::Pin instead of u32 for the pin definition. 
I kept the old constructor for backwards compatibility and added a deprecation warning.

- Hendrik